### PR TITLE
Update bidict 0.23.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,39 @@
 {% set name = "bidict" %}
-{% set version = "0.21.2" %}
-{% set compress_type = "tar.gz" %}
-{% set hash_val = "4fa46f7ff96dc244abfc437383d987404ae861df797e2fd5b190e233c302be09" %}
+{% set version = "0.23.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ compress_type }}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ hash_val }}
+  sha256: 03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71
 
 build:
-  noarch: python
+  skip: true  # [py<38]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
-    - setuptools_scm
+    - wheel
 
   run:
-    - python >=3.6
-    - setuptools
+    - python
 
 test:
   imports:
     - bidict
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: https://bidict.readthedocs.io
+  home: https://github.com/jab/bidict
   license: MPL-2.0
   license_file: LICENSE
   summary: Efficient, Pythonic bidirectional map implementation and related functionality

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
     - pip
     - pytest
     - hypothesis
+    - typing_extensions
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,13 @@
 {% set name = "bidict" %}
 {% set version = "0.23.1" %}
-{% set commit_id = "636f5a610f0e0b9a1e056fc72b688720c114403b" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71
-    # tests and tests data files
-  - url: https://github.com/jab/bidict/archive/{{ commit_id }}.tar.gz
-    sha256: 97c6b21db087960ed54752aaaf800cd52fe2f31cc3d48efde727c43e1704bf8d
-    folder: tests
+  url: https://github.com/jab/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b3619436e1e1e3cba15856839666edcb769fce97b47f5bba5e2789b03eed3156
 
 build:
   skip: true  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,18 @@
 {% set name = "bidict" %}
 {% set version = "0.23.1" %}
+{% set commit_id = "636f5a610f0e0b9a1e056fc72b688720c114403b" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71
+    # tests and tests data files
+  - url: https://github.com/jab/bidict/archive/{{ commit_id }}.tar.gz
+    sha256: 97c6b21db087960ed54752aaaf800cd52fe2f31cc3d48efde727c43e1704bf8d
+    folder: tests
 
 build:
   skip: true  # [py<38]
@@ -18,7 +23,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=40.9.0
     - wheel
 
   run:
@@ -27,18 +32,25 @@ requirements:
 test:
   imports:
     - bidict
+  source_files:
+    - tests
   requires:
     - pip
+    - pytest
+    - hypothesis
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - python -m pytest
 
 about:
-  home: https://github.com/jab/bidict
+  home: https://bidict.readthedocs.io
   license: MPL-2.0
   license_file: LICENSE
   license_family: MOZILLA
-  summary: Efficient, Pythonic bidirectional map implementation and related functionality
-  description: The bidirectional mapping library for Python.
+  summary: The bidirectional mapping library for Python.
+  description: |
+    The bidict library provides several friendly, efficient data structures for working with bidirectional mappings in Python.
   dev_url: https://github.com/jab/bidict
   doc_url: https://bidict.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - python -m pytest
+    - python -m pytest -v tests
 
 about:
   home: https://bidict.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,9 @@ about:
   home: https://github.com/jab/bidict
   license: MPL-2.0
   license_file: LICENSE
+  license_family: MOZILLA
   summary: Efficient, Pythonic bidirectional map implementation and related functionality
+  description: The bidirectional mapping library for Python.
   dev_url: https://github.com/jab/bidict
   doc_url: https://bidict.readthedocs.io
 


### PR DESCRIPTION
bidict 0.23.1

**Destination channel:** defaults

### Links
[PKG-8428](https://anaconda.atlassian.net/browse/PKG-8428) 
dev_url: https://github.com/jab/bidict/tree/v0.23.1
conda_forge: https://github.com/conda-forge/bidict-feedstock
pypi: https://pypi.org/project/bidict/0.23.1
pypi inspector: https://inspector.pypi.io/project/bidict/0.23.1

### Explanation of changes:

- New version numbers
- Running tests
- Update information about package


[PKG-8428]: https://anaconda.atlassian.net/browse/PKG-8428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ